### PR TITLE
fix bug where deployment was done with dev builds

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ case $ENV in
 esac
 
 #create a build
-npm run build
+npm run build-production
 
 echo "deploying build to $S3_BUCKET"
 aws s3  --profile 'stylepoints' sync ./build $S3_BUCKET --exclude 'deploy.sh' --exclude '.DS_Store' --delete

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "build": "webpack -c --progress -v",
+    "build-production": "NODE_ENV=production webpack -c --progress",
     "lint": "eslint --ignore-path .gitignore . --fix",
     "prebuild": "rimraf build/*",
     "prestart": "npm run build",


### PR DESCRIPTION
the deploy command was running `npm run build` which would read the local `NODE_ENV` var resulting in a dev build being deployed.
This adds `npm run build-production` which forces `NODE_ENV=production` before creating the build.