### PR TITLE
add invalidations to deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,3 +17,13 @@ npm run build-production
 echo "deploying build to $S3_BUCKET"
 aws s3  --profile 'stylepoints' sync ./build $S3_BUCKET --exclude 'deploy.sh' --exclude '.DS_Store' --delete
 
+# if production, invalidate key files in cloudfront
+if [ $ENV = 'production' ]
+then
+	echo "creating cloudfront invalidations"
+	aws configure --profile 'stylepoints' set preview.cloudfront true
+	aws cloudfront --profile 'stylepoints' create-invalidation --distribution-id ESLF5DK9C4OE9 \
+	  --paths /multiple_choice.js \
+			/index.html \
+			/article.html
+fi


### PR DESCRIPTION
if deploying to production server, also create Cloudfront invalidations. Cloudfront distribution ID is hardcoded for now